### PR TITLE
adding glup task to bin/start-servers.dev script

### DIFF
--- a/bin/start-servers-dev
+++ b/bin/start-servers-dev
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 #export TM_SITE_DATA=SiteData_TM
+echo [bash] starting gulp watch
+cd build/TM_Gulp/
+npm run gulp-watch &
 
+cd ../..
 echo [bash] Starting TM_Website
 cd  code/TM_Website
 npm start &


### PR DESCRIPTION
With this all the dev has to do in order to start a local server and the gulp compilation is `./bin/start-servers-dev`
